### PR TITLE
Change default max retry to 0

### DIFF
--- a/src/LoadBalanced/Templates/Rest/Client/ConfigTemplate.cshtml
+++ b/src/LoadBalanced/Templates/Rest/Client/ConfigTemplate.cshtml
@@ -21,7 +21,7 @@ namespace @Settings.Namespace
         public ShouldRetryPredicate ShouldRetryPredicate { get; }
         public CustomCheckIsErrorResponse IsErrorResponse { get; }
 
-        protected LoadBalancingConfigBase(IEnumerable<string> baseUrls, int maxRetry = 3, CustomCheckIsErrorResponse isErrorResponse = null)
+        protected LoadBalancingConfigBase(IEnumerable<string> baseUrls, int maxRetry = 0, CustomCheckIsErrorResponse isErrorResponse = null)
         {
             UrlResourceManager = ResourceManager.Create(baseUrls);
             ShouldRetryPredicate = GetRetryCountPredicate(maxRetry);


### PR DESCRIPTION
Change default max retry to 0 to make sure that developer doesn't accidently leave default value and retry request that shouldn't be retried.