### PR TITLE
Skip folder deletion

### DIFF
--- a/build/create-project.sh
+++ b/build/create-project.sh
@@ -70,7 +70,5 @@ if [ "$SHOULD_PUSH_NUGET" = "false" ]; then
   echo "Nuget is not pushed because SHOULD_PUSH_NUGET is set to $SHOULD_PUSH_NUGET , clean up will not run"
 else
   dotnet nuget push $OUTPUT_PATH/bin/Debug/$NAMESPACE.$VERSION.nupkg -k $NUGET_KEY -s https://hk-lib-nuget.agodadev.io/api/odata
-  rm -rf /src/output
-  rm -rf /src/input
 fi
 


### PR DESCRIPTION
Keep the output folder as should be running the docker from Gitlab CI. We need the output folder for Gitlab artifacts.